### PR TITLE
Fixed a bug that caused the binary lenght ot be 20 when generating xid from a string

### DIFF
--- a/xid/xid.py
+++ b/xid/xid.py
@@ -140,7 +140,7 @@ class XID:
         else:
             dec = DECODING_MAP
 
-        id_ = bytearray(ENCODED_LEN)
+        id_ = bytearray(RAW_LEN)
 
         if len(src) != ENCODED_LEN:
             raise InvalidXID()


### PR DESCRIPTION
Thank you for publishing the xid implementation.
I have generated an xid object from the xid string and also obtained its binary, which seems to be of different length.
I would appreciate your confirmation.

```python
import xid

guid = xid.XID()
guid_b = guid.bytes()
guid_b_from_string = xid.XID(guid.string()).bytes()
print("guid bytes len %s, guid bytes form string len %s" % (len(guid_b), len(guid_b_from_string)))
# guid bytes len 12, guid bytes form string len 20
```